### PR TITLE
Changed color scheme for Dark Mode and added custom colors for overview banner

### DIFF
--- a/src/components/dashboard/overview/overview-banner.js
+++ b/src/components/dashboard/overview/overview-banner.js
@@ -1,8 +1,17 @@
 import PropTypes from 'prop-types';
 import { Box, Button, Card, Chip, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 
 export const OverviewBanner = (props) => {
   const { onDismiss, ...other } = props;
+  const theme = useTheme();
+  const isDarkMode = theme.palette.mode == 'dark';
+
+  const bannerForDark = {
+    main: '#29313D',
+    hover: '#1B2028',
+    contrastText: '#FFFFFF'
+  };
 
   return (
     <Card
@@ -36,10 +45,20 @@ export const OverviewBanner = (props) => {
       </Box>
       <div>
         <div>
+          {isDarkMode ? (
+            <Chip
+              label="New"
+              sx={{
+                backgroundColor: bannerForDark.main,
+                color: bannerForDark.contrastText
+              }}
+            />
+          ) : (
           <Chip
             color="secondary"
             label="New"
           />
+          )}
         </div>
         <Typography
           color="inherit"
@@ -56,13 +75,29 @@ export const OverviewBanner = (props) => {
           Your dashboard has been improved!
         </Typography>
         <Box sx={{ mt: 2 }}>
-          <Button
+          {isDarkMode ? (
+            <Button
+              onClick={onDismiss}
+              variant="contained"
+              sx={{
+                backgroundColor: bannerForDark.main,
+                color: bannerForDark.contrastText,
+                '&:hover': {
+                  backgroundColor: bannerForDark.hover
+                }
+              }}
+            >
+              Dismiss Banner
+            </Button>
+          ) : (
+            <Button
             color="secondary"
             onClick={onDismiss}
             variant="contained"
           >
             Dismiss Banner
           </Button>
+          )}
         </Box>
       </div>
     </Card>

--- a/src/theme/dark-theme-options.js
+++ b/src/theme/dark-theme-options.js
@@ -9,7 +9,7 @@ const neutral = {
   600: '#4B5563',
   700: '#374151',
   800: '#1F2937',
-  900: '#111827'
+  900: '#0A0E1A'
 };
 
 const background = {
@@ -17,13 +17,20 @@ const background = {
   paper: neutral[900]
 };
 
-const divider = '#2D3748';
+const divider = '#1F2933';
+
+// const primary = {
+//   main: '#5C6BC0',
+//   light: '#8C9EFF',
+//   dark: '#3F51B5',
+//   contrastText: neutral[900]
+// };
 
 const primary = {
-  main: '#7582EB',
-  light: '#909BEF',
-  dark: '#515BA4',
-  contrastText: neutral[900]
+  main: neutral[600],
+  light: neutral[400],
+  dark: neutral[700],
+  contrastText: neutral[100]
 };
 
 const secondary = {
@@ -34,9 +41,9 @@ const secondary = {
 };
 
 const success = {
-  main: '#14B8A6',
-  light: '#43C6B7',
-  dark: '#0E8074',
+  main: '#22C55E',
+  light: '#4ADE80',
+  dark: '#15803D',
   contrastText: neutral[900]
 };
 
@@ -48,9 +55,9 @@ const info = {
 };
 
 const warning = {
-  main: '#FFB020',
-  light: '#FFBF4C',
-  dark: '#B27B16',
+  main: '#F59E0B',
+  light: '#FBBF24',
+  dark: '#B45309',
   contrastText: neutral[900]
 };
 
@@ -62,9 +69,9 @@ const error = {
 };
 
 const text = {
-  primary: '#EDF2F7',
-  secondary: '#A0AEC0',
-  disabled: 'rgba(255, 255, 255, 0.48)'
+  primary: '#F5F7FA',  
+  secondary: '#CBD5E1',
+  disabled: 'rgb(255, 255, 255, 0.38)'
 };
 
 export const darkThemeOptions = {
@@ -108,7 +115,7 @@ export const darkThemeOptions = {
     MuiOutlinedInput: {
       styleOverrides: {
         notchedOutline: {
-          borderColor: divider
+          borderColor: neutral[200]
         }
       }
     },
@@ -153,11 +160,29 @@ export const darkThemeOptions = {
         root: {
           backgroundColor: neutral[800],
           '.MuiTableCell-root': {
-            color: neutral[300]
+            color: neutral[800]
           }
         }
       }
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundColor: neutral[800],
+          borderRadius: '12px'
+        },
+        elevation1: {
+          boxShadow: '0px 4px 12px rgba(0,0,0,0.25)'
+        }
+      }
+    },
+    MuiButton: {
+    styleOverrides: {
+      root: {
+        color: '#FFFFFF' 
+      }
     }
+  }
   },
   palette: {
     action: {


### PR DESCRIPTION
Updated dark mode theme to a greyscale color scheme. Added a custom color scheme specifically for the dark mode's overview banner on the home page. Changed the color for the buttons for better readability too.

Did not make any changes to the light mode theme. 